### PR TITLE
.env ファイルの読み込みエラーをログ出力に変更

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,6 @@
 mod f2h;
 mod translate;
 
-use anyhow::Context as _;
 use clap::{CommandFactory, Parser};
 use clap_complete::{Generator, Shell, generate};
 use log::{Level, info};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,7 +44,11 @@ impl Route for Args {
             generate_completions(*shell);
         } else {
             initialize_logger(self.verbose);
-            dotenvy::dotenv().context("Failed to load .env file")?;
+
+            if let Err(e) = dotenvy::dotenv() {
+                log::warn!("Failed to load .env file: {}", e);
+            }
+
             let start = Instant::now();
 
             if let Some(command) = &self.command {


### PR DESCRIPTION
- .env ファイル読み込み時のエラーを警告ログとして表示
- エラー発生時にプログラムの実行を中断しない
- エラーの詳細をログに記録
